### PR TITLE
Check date from data integrity check proof against validity period

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zkpassport/sdk",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@aztec/bb.js": "^0.67.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Privacy-preserving identity verification using passports and ID cards",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
Makes the check for the date when the data integrity proof was generated more flexible by checking it against a validity period. The validity defaults to 6 months but can also be customized in the request configs.