### PR TITLE
Updating to circuits v0.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zkpassport/sdk",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aztec/bb.js": "^0.67.0",
+        "@aztec/bb.js": "^0.76.4",
         "@noble/ciphers": "^1.2.1",
         "@noble/secp256k1": "^2.2.3",
-        "@zkpassport/utils": "^0.2.16",
+        "@zkpassport/utils": "^0.2.21",
         "buffer": "^6.0.3",
         "i18n-iso-countries": "^7.12.0",
         "pako": "^2.1.0",
@@ -46,12 +46,12 @@
       }
     },
     "node_modules/@aztec/bb.js": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@aztec/bb.js/-/bb.js-0.67.1.tgz",
-      "integrity": "sha512-Ieb+JPCLfIYDw78/calOG1mw/i7i1CF2YT8lcl+yp4oiw0+NaAACWgLc9n7MtDEAa2Oyahw4W7bN2AEDJ0usgg==",
+      "version": "0.76.4",
+      "resolved": "https://registry.npmjs.org/@aztec/bb.js/-/bb.js-0.76.4.tgz",
+      "integrity": "sha512-KCQ/y5RDxXvX6LIGTfAlqH0LhiVJK54tbehrjIBEs/KBLSHdaTm/mWsd/nu7YupD4t6doCoqODapmu7Dly1NxQ==",
       "dependencies": {
         "comlink": "^4.4.1",
-        "commander": "^10.0.1",
+        "commander": "^12.1.0",
         "debug": "^4.3.4",
         "fflate": "^0.8.0",
         "pako": "^2.1.0",
@@ -2501,14 +2501,14 @@
       }
     },
     "node_modules/@zkpassport/poseidon2": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@zkpassport/poseidon2/-/poseidon2-0.5.3.tgz",
-      "integrity": "sha512-YL53venDhwO4lFBWABuR5kCfCulCvamKL44o5ne9yezutxSH0pHJZxNjUhZ3RwWisSwzxSmZ72ZbtW90cqhHVw=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@zkpassport/poseidon2/-/poseidon2-0.6.1.tgz",
+      "integrity": "sha512-9jDOgCvZvrfZAoobPjDVKnBmcjE9HP2HwlCc/dpwAr87ERzGyV0WqY6y0AkomtlYEJIaAtAEjLeRgmKKNIqFCg=="
     },
     "node_modules/@zkpassport/utils": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@zkpassport/utils/-/utils-0.2.16.tgz",
-      "integrity": "sha512-lUccu17DYjFM61lHILVbO0pwkR2lb7/zUVfmRlGU8aagXzYeutTSx3TBZ9M8aP4PFiERa7P3jM/LAI9LhnEEqg==",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@zkpassport/utils/-/utils-0.2.21.tgz",
+      "integrity": "sha512-go6wA5qsuUpd0cSUd4oHDkKOoKUounjFZIlXscZrJCmh8IWGtxN1jSBmaZ3vT1pjcAxmJcSDBn0syeKZV+u5pQ==",
       "dependencies": {
         "@lapo/asn1js": "^2.0.4",
         "@noble/ciphers": "^1.0.0",
@@ -2522,7 +2522,7 @@
         "@peculiar/asn1-x509": "^2.3.13",
         "@peculiar/x509": "^1.12.3",
         "@zk-kit/utils": "^1.2.1",
-        "@zkpassport/poseidon2": "^0.5.3",
+        "@zkpassport/poseidon2": "^0.6.0",
         "date-fns": "^4.1.0",
         "i18n-iso-countries": "^7.13.0"
       }
@@ -3035,11 +3035,11 @@
       "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g=="
     },
     "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aztec/bb.js": "^0.76.4",
         "@noble/ciphers": "^1.2.1",
         "@noble/secp256k1": "^2.2.3",
-        "@zkpassport/utils": "^0.2.21",
+        "@zkpassport/utils": "^0.2.23",
         "buffer": "^6.0.3",
         "i18n-iso-countries": "^7.12.0",
         "pako": "^2.1.0",
@@ -2506,9 +2506,9 @@
       "integrity": "sha512-9jDOgCvZvrfZAoobPjDVKnBmcjE9HP2HwlCc/dpwAr87ERzGyV0WqY6y0AkomtlYEJIaAtAEjLeRgmKKNIqFCg=="
     },
     "node_modules/@zkpassport/utils": {
-      "version": "0.2.21",
-      "resolved": "https://registry.npmjs.org/@zkpassport/utils/-/utils-0.2.21.tgz",
-      "integrity": "sha512-go6wA5qsuUpd0cSUd4oHDkKOoKUounjFZIlXscZrJCmh8IWGtxN1jSBmaZ3vT1pjcAxmJcSDBn0syeKZV+u5pQ==",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@zkpassport/utils/-/utils-0.2.23.tgz",
+      "integrity": "sha512-5PsNuvkhGhxSiPs/r81alwT+NAV1GTno7JrO5mBC4fV6jEHOhJHRvlOLCW4aQHPVOCUFe8AfFMVPalPgzAyH/w==",
       "dependencies": {
         "@lapo/asn1js": "^2.0.4",
         "@noble/ciphers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Privacy-preserving identity verification using passports and ID cards",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -38,10 +38,10 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "@aztec/bb.js": "^0.67.0",
+    "@aztec/bb.js": "^0.76.4",
     "@noble/ciphers": "^1.2.1",
     "@noble/secp256k1": "^2.2.3",
-    "@zkpassport/utils": "^0.2.16",
+    "@zkpassport/utils": "^0.2.21",
     "buffer": "^6.0.3",
     "i18n-iso-countries": "^7.12.0",
     "pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@aztec/bb.js": "^0.76.4",
     "@noble/ciphers": "^1.2.1",
     "@noble/secp256k1": "^2.2.3",
-    "@zkpassport/utils": "^0.2.21",
+    "@zkpassport/utils": "^0.2.23",
     "buffer": "^6.0.3",
     "i18n-iso-countries": "^7.12.0",
     "pako": "^2.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,13 +263,19 @@ export type QueryBuilder = {
    * @param key The attribute to compare.
    * @param value The list of values to check inclusion against.
    */
-  in: <T extends "nationality">(key: T, value: IDCredentialValue<T>[]) => QueryBuilder
+  in: <T extends "nationality" | "issuing_country">(
+    key: T,
+    value: IDCredentialValue<T>[],
+  ) => QueryBuilder
   /**
    * Requires this attribute to be excluded from the provided list.
    * @param key The attribute to compare.
    * @param value The list of values to check exclusion against.
    */
-  out: <T extends "nationality">(key: T, value: IDCredentialValue<T>[]) => QueryBuilder
+  out: <T extends "nationality" | "issuing_country">(
+    key: T,
+    value: IDCredentialValue<T>[],
+  ) => QueryBuilder
   /**
    * Requires this attribute to be disclosed.
    * @param key The attribute to disclose.
@@ -399,13 +405,29 @@ export class ZKPassport {
             }
             break
           case "in":
-            if (field === "nationality" && !neededCircuits.includes("inclusion_check_country")) {
-              neededCircuits.push("inclusion_check_country")
+            if (
+              field === "nationality" &&
+              !neededCircuits.includes("inclusion_check_nationality")
+            ) {
+              neededCircuits.push("inclusion_check_nationality")
+            } else if (
+              field === "issuing_country" &&
+              !neededCircuits.includes("inclusion_check_issuing_country")
+            ) {
+              neededCircuits.push("inclusion_check_issuing_country")
             }
             break
           case "out":
-            if (field === "nationality" && !neededCircuits.includes("exclusion_check_country")) {
-              neededCircuits.push("exclusion_check_country")
+            if (
+              field === "nationality" &&
+              !neededCircuits.includes("exclusion_check_nationality")
+            ) {
+              neededCircuits.push("exclusion_check_nationality")
+            } else if (
+              field === "issuing_country" &&
+              !neededCircuits.includes("exclusion_check_issuing_country")
+            ) {
+              neededCircuits.push("exclusion_check_issuing_country")
             }
             break
         }
@@ -853,7 +875,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.document_type.eq = {
               expected: `${queryResult.document_type.eq.expected}`,
-              received: `${disclosedDataPassport.documentType}`,
+              received: `${disclosedDataPassport.documentType ?? disclosedDataIDCard.documentType}`,
               message: "Document type does not match the expected document type",
             }
           }
@@ -862,7 +884,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.document_type.disclose = {
               expected: `${queryResult.document_type.disclose?.result}`,
-              received: `${disclosedDataIDCard.documentType}`,
+              received: `${disclosedDataIDCard.documentType ?? disclosedDataPassport.documentType}`,
               message: "Document type does not match the disclosed document type in query result",
             }
           }
@@ -880,7 +902,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.birthdate.eq = {
               expected: `${queryResult.birthdate.eq.expected.toISOString()}`,
-              received: `${birthdatePassport.toISOString()}`,
+              received: `${birthdatePassport?.toISOString() ?? birthdateIDCard?.toISOString()}`,
               message: "Birthdate does not match the expected birthdate",
             }
           }
@@ -893,7 +915,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.birthdate.disclose = {
               expected: `${queryResult.birthdate.disclose.result.toISOString()}`,
-              received: `${birthdatePassport.toISOString()}`,
+              received: `${birthdatePassport?.toISOString() ?? birthdateIDCard?.toISOString()}`,
               message: "Birthdate does not match the disclosed birthdate in query result",
             }
           }
@@ -911,7 +933,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.expiry_date.eq = {
               expected: `${queryResult.expiry_date.eq.expected.toISOString()}`,
-              received: `${expiryDatePassport.toISOString()}`,
+              received: `${expiryDatePassport?.toISOString() ?? expiryDateIDCard?.toISOString()}`,
               message: "Expiry date does not match the expected expiry date",
             }
           }
@@ -924,7 +946,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.expiry_date.disclose = {
               expected: `${queryResult.expiry_date.disclose.result.toISOString()}`,
-              received: `${expiryDatePassport.toISOString()}`,
+              received: `${expiryDatePassport?.toISOString() ?? expiryDateIDCard?.toISOString()}`,
               message: "Expiry date does not match the disclosed expiry date in query result",
             }
           }
@@ -942,7 +964,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.nationality.eq = {
               expected: `${queryResult.nationality.eq.expected}`,
-              received: `${nationalityPassport}`,
+              received: `${nationalityPassport ?? nationalityIDCard}`,
               message: "Nationality does not match the expected nationality",
             }
           }
@@ -955,7 +977,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.nationality.disclose = {
               expected: `${queryResult.nationality.disclose.result}`,
-              received: `${nationalityPassport}`,
+              received: `${nationalityPassport ?? nationalityIDCard}`,
               message: "Nationality does not match the disclosed nationality in query result",
             }
           }
@@ -973,7 +995,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.document_number.eq = {
               expected: `${queryResult.document_number.eq.expected}`,
-              received: `${documentNumberPassport}`,
+              received: `${documentNumberPassport ?? documentNumberIDCard}`,
               message: "Document number does not match the expected document number",
             }
           }
@@ -988,7 +1010,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.document_number.disclose = {
               expected: `${queryResult.document_number.disclose.result}`,
-              received: `${documentNumberPassport}`,
+              received: `${documentNumberPassport ?? documentNumberIDCard}`,
               message:
                 "Document number does not match the disclosed document number in query result",
             }
@@ -1007,7 +1029,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.gender.eq = {
               expected: `${queryResult.gender.eq.expected}`,
-              received: `${genderPassport}`,
+              received: `${genderPassport ?? genderIDCard}`,
               message: "Gender does not match the expected gender",
             }
           }
@@ -1020,7 +1042,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.gender.disclose = {
               expected: `${queryResult.gender.disclose.result}`,
-              received: `${genderPassport}`,
+              received: `${genderPassport ?? genderIDCard}`,
               message: "Gender does not match the disclosed gender in query result",
             }
           }
@@ -1038,7 +1060,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.issuing_country.eq = {
               expected: `${queryResult.issuing_country.eq.expected}`,
-              received: `${issuingCountryPassport}`,
+              received: `${issuingCountryPassport ?? issuingCountryIDCard}`,
               message: "Issuing country does not match the expected issuing country",
             }
           }
@@ -1053,7 +1075,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.issuing_country.disclose = {
               expected: `${queryResult.issuing_country.disclose.result}`,
-              received: `${issuingCountryPassport}`,
+              received: `${issuingCountryPassport ?? issuingCountryIDCard}`,
               message:
                 "Issuing country does not match the disclosed issuing country in query result",
             }
@@ -1074,7 +1096,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.fullname.eq = {
               expected: `${queryResult.fullname.eq.expected}`,
-              received: `${fullnamePassport}`,
+              received: `${fullnamePassport ?? fullnameIDCard}`,
               message: "Fullname does not match the expected fullname",
             }
           }
@@ -1089,7 +1111,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.fullname.disclose = {
               expected: `${queryResult.fullname.disclose.result}`,
-              received: `${fullnamePassport}`,
+              received: `${fullnamePassport ?? fullnameIDCard}`,
               message: "Fullname does not match the disclosed fullname in query result",
             }
           }
@@ -1116,7 +1138,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.firstname.eq = {
               expected: `${queryResult.firstname.eq.expected}`,
-              received: `${firstnamePassport}`,
+              received: `${firstnamePassport ?? firstnameIDCard}`,
               message: "Firstname does not match the expected firstname",
             }
           }
@@ -1131,7 +1153,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.firstname.disclose = {
               expected: `${queryResult.firstname.disclose.result}`,
-              received: `${firstnamePassport}`,
+              received: `${firstnamePassport ?? firstnameIDCard}`,
               message: "Firstname does not match the disclosed firstname in query result",
             }
           }
@@ -1158,7 +1180,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.lastname.eq = {
               expected: `${queryResult.lastname.eq.expected}`,
-              received: `${lastnamePassport}`,
+              received: `${lastnamePassport ?? lastnameIDCard}`,
               message: "Lastname does not match the expected lastname",
             }
           }
@@ -1173,7 +1195,7 @@ export class ZKPassport {
             isCorrect = false
             queryResultErrors.lastname.disclose = {
               expected: `${queryResult.lastname.disclose.result}`,
-              received: `${lastnamePassport}`,
+              received: `${lastnamePassport ?? lastnameIDCard}`,
               message: "Lastname does not match the disclosed lastname in query result",
             }
           }


### PR DESCRIPTION
- Add support for the new circuits supporting sha384 and sha512 for the data integrity check and the signature algorithms (both for RSA and ECDSA)
- Enable inclusion and exclusion proofs for issuing country
- Fix issues related to the parsing of the ID holder's name
- Update proving backend (barretenberg 0.76.4)
- Make sure to support ID cards in query result errors