### PR TITLE
Simplify verify function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zkpassport/sdk",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@aztec/bb.js": "^0.76.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Privacy-preserving identity verification using passports and ID cards",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
Remove `verify` function dependence on the request id and internal state of ZKPassport instance to make it easier to use independently (notably for server-side use cases), with just the proofs and the query results provided as argument