### PR TITLE
Multiple certificate registry roots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zkpassport/sdk",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@aztec/bb.js": "^0.76.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Privacy-preserving identity verification using passports and ID cards",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -738,9 +738,10 @@ export class ZKPassport {
     let commitmentOut: bigint | undefined
     let isCorrect = true
     let uniqueIdentifier: string | undefined
-    const expectedMerkleRoot = BigInt(
-      "21301853597069384763054217328384418971999152625381818922211526730996340553696",
-    )
+    const VALID_CERTIFICATE_REGISTRY_ROOT = [
+      BigInt("20192042006788880778219739574377003123593792072535937278552252195461520776494"),
+      BigInt("21301853597069384763054217328384418971999152625381818922211526730996340553696"),
+    ]
     const defaultDateValue = new Date(1111, 10, 11)
     const currentTime = new Date()
     const today = new Date(
@@ -798,11 +799,11 @@ export class ZKPassport {
       if (proof.name?.startsWith("sig_check_dsc")) {
         commitmentOut = getCommitmentFromDSCProof(proofData)
         const merkleRoot = getMerkleRootFromDSCProof(proofData)
-        if (merkleRoot !== expectedMerkleRoot) {
+        if (!VALID_CERTIFICATE_REGISTRY_ROOT.includes(merkleRoot)) {
           console.warn("The ID was signed by an unrecognized root certificate")
           isCorrect = false
           queryResultErrors.sig_check_dsc.certificate = {
-            expected: `Certificate registry root: ${expectedMerkleRoot.toString()}`,
+            expected: `Certificate registry root: ${VALID_CERTIFICATE_REGISTRY_ROOT.join(", ")}`,
             received: `Certificate registry root: ${merkleRoot.toString()}`,
             message: "The ID was signed by an unrecognized root certificate",
           }


### PR DESCRIPTION
Add the new certificate registry merkle root as part of the valid expected registry roots for the public input checks