### PR TITLE
Custom CRS path option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zkpassport/sdk",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aztec/bb.js": "^0.82.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Privacy-preserving identity verification using passports and ID cards",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ import ZKPassportVerifierAbi from "./assets/abi/ZKPassportVerifier.json"
 import { RegistryClient } from "@zkpassport/registry"
 import { Bridge, BridgeInterface } from "@obsidion/bridge"
 
-const VERSION = "0.5.0"
+const VERSION = "0.5.2"
 
 const DEFAULT_DATE_VALUE = new Date(1111, 10, 11)
 
@@ -2792,6 +2792,7 @@ export class ZKPassport {
     scope,
     evmChain,
     devMode = false,
+    crsPath,
   }: {
     proofs: Array<ProofResult>
     queryResult: QueryResult
@@ -2799,6 +2800,7 @@ export class ZKPassport {
     scope?: string
     evmChain?: EVMChain
     devMode?: boolean
+    crsPath?: string
   }): Promise<{
     uniqueIdentifier: string | undefined
     verified: boolean
@@ -2826,7 +2828,9 @@ export class ZKPassport {
     }
 
     const { BarretenbergVerifier } = await import("@aztec/bb.js")
-    const verifier = new BarretenbergVerifier()
+    const verifier = new BarretenbergVerifier({
+      crsPath,
+    })
     let verified = true
     let uniqueIdentifier: string | undefined
     let queryResultErrors: QueryResultErrors | undefined


### PR DESCRIPTION
This PR adds the option to specify a custom path for the CRS used by the Barretenberg verifier. This can help fix issues with some environments (e.g. Next.js on Vercel) having restrictions on which locations files can be written. Although ultimately, this should be managed automatically by the SDK, as this is an overly complex idea to expose at the level of the SDK