### PR TITLE
Custom writing directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zkpassport/sdk",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aztec/bb.js": "^0.82.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkpassport/sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Privacy-preserving identity verification using passports and ID cards",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
This PR changes the option of custom CRS path to custom writing directory to abstract away the notion of CRS. It also automatically default to the `/tmp` directory on server-side environments so it works out of the box with Vercel.